### PR TITLE
Use FXML for board UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ Available solvers
 Available visualization
 ============================
 * Java implementation has a console output which indicates the number of possible combinations
- and the placement of figures in each found solution
+  and the placement of figures in each found solution
+* Starting from version 1.0 you can launch a JavaFX based UI defined in an FXML layout to browse the solutions.
+  Build the project and run `com.gitlab.saylenty.chessPl.ui.ChessBoardApplication`.
 
 Examples
 ============================

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,16 @@
             <artifactId>jackson-databind</artifactId>
             <version>2.10.0.pr1</version>
         </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-controls</artifactId>
+            <version>21.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-fxml</artifactId>
+            <version>21.0.2</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/src/main/java/com/gitlab/saylenty/chessPl/logic/BFRecursiveStrategy.java
+++ b/src/main/java/com/gitlab/saylenty/chessPl/logic/BFRecursiveStrategy.java
@@ -24,15 +24,19 @@ public class BFRecursiveStrategy implements PlacementStrategy {
 
     private final ChessBoard board;
     private final List<Piece> pieces;
+    private final Consumer<Stream<? extends Piece>> solutionConsumer;
+
+    public BFRecursiveStrategy(ChessBoard board, List<Piece> pieces) {
+        this(board, pieces, set -> {
+            set.forEach(System.out::println);
+            System.out.println();
+        });
+    }
 
     @Override
     public int play() {
         // calculate the number of figures possible combinations
-        return recursiveStrategy(0, 0, set -> {
-            // print result
-            set.forEach(System.out::println);
-            System.out.println();
-        });
+        return recursiveStrategy(0, 0, solutionConsumer);
     }
 
     private int recursiveStrategy(int startIndex, int seed, Consumer<Stream<? extends Piece>> solutionConsumer) {

--- a/src/main/java/com/gitlab/saylenty/chessPl/ui/ChessBoardApplication.java
+++ b/src/main/java/com/gitlab/saylenty/chessPl/ui/ChessBoardApplication.java
@@ -1,0 +1,26 @@
+package com.gitlab.saylenty.chessPl.ui;
+
+import javafx.application.Application;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Scene;
+import javafx.stage.Stage;
+
+/**
+ * Launches the JavaFX UI defined in FXML.
+ */
+public class ChessBoardApplication extends Application {
+
+    @Override
+    public void start(Stage stage) throws Exception {
+        FXMLLoader loader = new FXMLLoader(
+            getClass().getResource("/com/gitlab/saylenty/chessPl/ui/board.fxml"));
+        Scene scene = new Scene(loader.load());
+        stage.setTitle("Chess Solutions");
+        stage.setScene(scene);
+        stage.show();
+    }
+
+    public static void main(String[] args) {
+        launch(args);
+    }
+}

--- a/src/main/java/com/gitlab/saylenty/chessPl/ui/ChessBoardController.java
+++ b/src/main/java/com/gitlab/saylenty/chessPl/ui/ChessBoardController.java
@@ -1,0 +1,158 @@
+package com.gitlab.saylenty.chessPl.ui;
+
+import com.gitlab.saylenty.chessPl.gameItems.ChessBoard;
+import com.gitlab.saylenty.chessPl.gameItems.BoardSquare;
+import com.gitlab.saylenty.chessPl.gameItems.GamePiecesFactory;
+import com.gitlab.saylenty.chessPl.gameItems.pieces.Piece;
+import com.gitlab.saylenty.chessPl.gameItems.pieces.Queen;
+import com.gitlab.saylenty.chessPl.logic.BFRecursiveStrategy;
+import javafx.fxml.FXML;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.StackPane;
+import javafx.scene.paint.Color;
+import javafx.scene.shape.Rectangle;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Controller for the chess board UI loaded from FXML.
+ */
+public class ChessBoardController {
+
+    private static final int SIZE = 8;
+
+    @FXML
+    private GridPane boardGrid;
+    @FXML
+    private Button prevButton;
+    @FXML
+    private Button nextButton;
+    @FXML
+    private Button dangerButton;
+
+    private List<List<PieceSnapshot>> solutions;
+    private int current;
+    private boolean showAllDanger;
+    private final Set<PieceSnapshot> activeDanger = new HashSet<>();
+
+    @FXML
+    private void initialize() {
+        collectSolutions();
+        drawBoard();
+        showSolution(0);
+    }
+
+    @FXML
+    private void handlePrev() {
+        showSolution(current - 1);
+    }
+
+    @FXML
+    private void handleNext() {
+        showSolution(current + 1);
+    }
+
+    @FXML
+    private void handleToggleDanger() {
+        showAllDanger = !showAllDanger;
+        renderCurrent();
+    }
+
+    private void drawBoard() {
+        for (int y = 0; y < SIZE; y++) {
+            for (int x = 0; x < SIZE; x++) {
+                StackPane cell = new StackPane();
+                Rectangle r = new Rectangle(40, 40);
+                r.setFill((x + y) % 2 == 0 ? Color.BEIGE : Color.BROWN);
+                cell.getChildren().add(r);
+                boardGrid.add(cell, x, y);
+            }
+        }
+    }
+
+    private void collectSolutions() {
+        ChessBoard board = new ChessBoard(SIZE, SIZE);
+        GamePiecesFactory factory = new GamePiecesFactory();
+        List<Piece> pieces = new ArrayList<>();
+        for (int i = 0; i < SIZE; i++) {
+            pieces.add(factory.createPiece(Queen.class, Piece.Color.BLACK, board));
+        }
+        List<List<PieceSnapshot>> list = new ArrayList<>();
+        BFRecursiveStrategy strategy = new BFRecursiveStrategy(board, pieces, stream -> {
+            list.add(stream.map(p -> new PieceSnapshot(p.getClass(), p.getColor(),
+                    p.getPosition().getX(), p.getPosition().getY()))
+                    .collect(Collectors.toList()));
+        });
+        strategy.play();
+        solutions = list;
+    }
+
+    private void showSolution(int index) {
+        if (index < 0 || index >= solutions.size()) {
+            return;
+        }
+        current = index;
+        activeDanger.clear();
+        renderCurrent();
+    }
+
+    private void renderCurrent() {
+        List<PieceSnapshot> solution = solutions.get(current);
+        for (int y = 0; y < SIZE; y++) {
+            for (int x = 0; x < SIZE; x++) {
+                StackPane cell = getCell(x, y);
+                Rectangle r = (Rectangle) cell.getChildren().get(0);
+                r.setStroke(null);
+                if (cell.getChildren().size() > 1) cell.getChildren().remove(1);
+            }
+        }
+        for (PieceSnapshot ps : solution) {
+            StackPane cell = getCell(ps.x(), ps.y());
+            Label lbl = new Label("Q");
+            cell.getChildren().add(lbl);
+            cell.setOnMouseClicked(e -> togglePiece(ps));
+        }
+        if (showAllDanger) {
+            solution.forEach(activeDanger::add);
+        }
+        for (PieceSnapshot ps : activeDanger) {
+            highlightDanger(ps);
+        }
+    }
+
+    private StackPane getCell(int x, int y) {
+        for (javafx.scene.Node node : boardGrid.getChildren()) {
+            if (GridPane.getColumnIndex(node) == x && GridPane.getRowIndex(node) == y) {
+                return (StackPane) node;
+            }
+        }
+        return null;
+    }
+
+    private void togglePiece(PieceSnapshot ps) {
+        if (activeDanger.contains(ps)) {
+            activeDanger.remove(ps);
+        } else {
+            activeDanger.add(ps);
+        }
+        renderCurrent();
+    }
+
+    private void highlightDanger(PieceSnapshot ps) {
+        ChessBoard board = new ChessBoard(SIZE, SIZE);
+        GamePiecesFactory factory = new GamePiecesFactory();
+        Piece piece = factory.createPiece((Class<? extends Piece>) ps.type(), ps.color(), board);
+        piece.setPosition(new BoardSquare(ps.x(), ps.y()));
+        for (BoardSquare square : piece.getCaptureZone()) {
+            StackPane cell = getCell(square.getX(), square.getY());
+            Rectangle r = (Rectangle) cell.getChildren().get(0);
+            r.setStroke(Color.RED);
+        }
+    }
+}

--- a/src/main/java/com/gitlab/saylenty/chessPl/ui/PieceSnapshot.java
+++ b/src/main/java/com/gitlab/saylenty/chessPl/ui/PieceSnapshot.java
@@ -1,0 +1,5 @@
+package com.gitlab.saylenty.chessPl.ui;
+
+import com.gitlab.saylenty.chessPl.gameItems.pieces.Piece;
+
+public record PieceSnapshot(Class<? extends Piece> type, Piece.Color color, int x, int y) {}

--- a/src/main/resources/com/gitlab/saylenty/chessPl/ui/board.fxml
+++ b/src/main/resources/com/gitlab/saylenty/chessPl/ui/board.fxml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?import javafx.scene.layout.*?>
+<?import javafx.scene.control.*?>
+
+<BorderPane xmlns:fx="http://javafx.com/fxml" xmlns="http://javafx.com/javafx" fx:controller="com.gitlab.saylenty.chessPl.ui.ChessBoardController">
+    <center>
+        <GridPane fx:id="boardGrid" />
+    </center>
+    <bottom>
+        <HBox alignment="CENTER" spacing="10">
+            <children>
+                <Button fx:id="prevButton" text="Prev" onAction="#handlePrev" />
+                <Button fx:id="nextButton" text="Next" onAction="#handleNext" />
+                <Button fx:id="dangerButton" text="Toggle danger" onAction="#handleToggleDanger" />
+            </children>
+        </HBox>
+    </bottom>
+</BorderPane>


### PR DESCRIPTION
## Summary
- document that the JavaFX UI uses an FXML layout
- add `javafx-fxml` dependency
- replace imperative UI code with FXML controller
- provide `board.fxml` file defining the layout

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6880ab950fe88321852d4e5ef59b33cb